### PR TITLE
Removed external dep for JWT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/vendor/
+vendor/
 .buildpath
 .project
 .settings/

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
 		"email" : "support@juspay.in"
 	}],
 	"require" : {
-		"php": ">=7.1.0",
+		"php": ">=5.6.0",
 		"ext-curl" : "*",
 		"ext-json" : "*",
-		"web-token/jwt-framework": "^3.0 || ^2.0 || ^1.0",
+		"phpseclib/phpseclib": "^3.0",
 		"monolog/monolog": "^3.0 || ^2.0 || ^1.0"
 	},
 	"provide" : {
@@ -30,7 +30,8 @@
 		"psr-4" : {
 			"Juspay\\" : "lib",
 			"Juspay\\Model\\" : "lib/Model",
-			"Juspay\\Exception\\" : "lib/Exception"
+			"Juspay\\Exception\\" : "lib/Exception",
+			"Juspay\\JWT\\": "lib/JWT"
 		}
 	},
 	"autoload-dev" : {

--- a/lib/JWT/AES256GCM.php
+++ b/lib/JWT/AES256GCM.php
@@ -1,0 +1,46 @@
+<?php
+namespace Juspay\JWT;
+use Juspay\JWT\IContentEncryption;
+use phpseclib3\Crypt\AES;
+class AES256GCM extends IContentEncryption {
+    public function encryptContent($data, $cek, $iv, $aad, $encodedProtectedHeaders, &$tag) {
+        $calculatedAad = $encodedProtectedHeaders;
+        if (null !== $aad) {
+            $calculatedAad .= '.'.$aad;
+        }
+
+        $aes = new AES('gcm');
+        $aes->setKeyLength($this->getCEKSize());
+        $aes->setNonce($iv);
+        $aes->setKey($cek);
+        $aes->setAAD($calculatedAad);
+        $cipherText = $aes->encrypt($data);
+        $tag = $aes->getTag();
+        return $cipherText;
+    }
+    public function decryptContent($data, $cek, $iv, $aad, $encodedProtectedHeaders, $tag) {
+        $calculatedAad = $encodedProtectedHeaders;
+        if (null !== $aad) {
+            $calculatedAad .= '.'.$aad;
+        }
+        $aes = new AES('gcm');
+        $aes->setNonce($iv);
+        $aes->setKey($cek);
+        $aes->setAAD($calculatedAad);
+        $aes->setTag($tag);
+        return $aes->decrypt($data);
+    }
+    
+    public function getIVSize() {
+        return 96;
+    }
+
+    public function getCEKSize() {
+        return 256;
+    }
+
+    public function getAlgorithmName() {
+        return 'A256GCM';
+    }
+}
+?>

--- a/lib/JWT/Base64Url.php
+++ b/lib/JWT/Base64Url.php
@@ -1,0 +1,28 @@
+<?php
+namespace Juspay\JWT;
+
+final class Base64Url
+{
+    /**
+     * @param string $data
+     * @param bool   $use_padding
+     *
+     * @return string
+     */
+    public static function encode($data, $use_padding = false)
+    {
+        $encoded = strtr(base64_encode($data), '+/', '-_');
+
+        return true === $use_padding ? $encoded : rtrim($encoded, '=');
+    }
+
+    /**
+     * @param string $data The data to decode
+     *
+     * @return string The data decoded
+     */
+    public static function decode($data)
+    {
+        return base64_decode(strtr($data, '-_', '+/'));
+    }
+}

--- a/lib/JWT/IContentEncryption.php
+++ b/lib/JWT/IContentEncryption.php
@@ -1,0 +1,14 @@
+<?php
+namespace Juspay\JWT;
+abstract class IContentEncryption {
+    abstract public function encryptContent($content, $cek, $iv, $aad, $protectedHeaders, &$tag);
+
+    abstract public function decryptContent($content, $cek, $iv, $aad, $protectedHeaders, $tag);
+
+    abstract public function getAlgorithmName();
+
+    abstract public function getIVSize();
+
+    abstract public function getCEKSize();
+}
+?>

--- a/lib/JWT/IKeyEncryption.php
+++ b/lib/JWT/IKeyEncryption.php
@@ -1,0 +1,10 @@
+<?php
+namespace Juspay\JWT;
+abstract class IKeyEncryption {
+    abstract public function encryptKey(JWk $key, $cek);
+
+    abstract public function decryptKey(JWK $key, $encryptedKey);
+
+    abstract public function getAlgorithmName();
+}
+?>

--- a/lib/JWT/ISigningAlgorithm.php
+++ b/lib/JWT/ISigningAlgorithm.php
@@ -1,0 +1,25 @@
+<?php
+namespace Juspay\JWT;
+abstract class ISigningAlgorithm {
+    /**
+     * Signer
+     * @param string $payload
+     * @param JWK $key
+     * @return string
+     */
+    abstract public function sign($payload, $key);
+
+    /**
+     * Verfiy the Signature
+     * @param string $payload
+     * @param string $signature
+     * @param JWK $key
+     */
+    abstract public function verifySign($payload, $signature, $key);
+
+    /**
+     * @return string
+     */
+    abstract public function getAlgorithmName();
+} 
+?>

--- a/lib/JWT/JWE.php
+++ b/lib/JWT/JWE.php
@@ -1,0 +1,147 @@
+<?php
+namespace Juspay\JWT;
+use Juspay\JWT\Base64Url;
+class JWE {
+    /**
+     * @var string
+     */
+    public $payload = null;
+
+    /**
+     * @var string
+     */
+    private $encryptedKey = null;
+
+    /**
+     * @var string
+     */
+
+     private $cek = null;
+    /**
+     * @var string|null
+     */
+    private $ciphertext = null;
+
+    /**
+     * @var string|null
+     */
+    private $iv = null;
+
+    /**
+     * @var string|null
+     */
+    private $aad = null;
+
+    /**
+     * @var string|null
+     */
+    private $tag = null;
+
+
+    /**
+     * @var array
+     */
+    private $sharedProtectedHeaders = [];
+
+    /**
+     * @var string|null
+     */
+    private $encodedSharedProtectedHeaders = null;
+
+    /**
+     * @var IKeyEncryption $keyEncryptionAlgorithm
+     */
+    private $keyEncryptionAlgorithm = null;
+
+    /**
+     * @var IContentEncryption $contentEncryptionAlgorithm
+     */
+    private $contentEncryptionAlgorithm = null;
+
+    /**
+     * @property IKeyEncryption $keyEncryptionAlgorithm
+     * @property IContentEncryption $contentEncryptionAlgorithm
+     */
+    public function __construct($keyEncryptionAlgorithm, $contentEncryptionAlgorithm) {
+        $this->keyEncryptionAlgorithm = $keyEncryptionAlgorithm;
+        $this->contentEncryptionAlgorithm = $contentEncryptionAlgorithm;
+        $this->sharedProtectedHeaders = [
+            'alg' => $this->keyEncryptionAlgorithm->getAlgorithmName(),
+            'enc' => $this->contentEncryptionAlgorithm->getAlgorithmName(),
+        ];
+    }
+
+    public function createCek() {
+        $size = $this->contentEncryptionAlgorithm->getCEKSize();
+        return random_bytes($size / 8);
+    }
+
+    public function createIV() {
+        $size = $this->contentEncryptionAlgorithm->getIVSize();
+        return random_bytes($size / 8);
+    }
+
+    public function setEncodedSharedProtectedHeaders() {
+        if (!empty($this->sharedProtectedHeaders) || !is_null($this->sharedProtectedHeaders)) {
+            $this->encodedSharedProtectedHeaders = Base64Url::encode(json_encode($this->sharedProtectedHeaders));
+        }
+    }
+
+    public function setSharedProtectedHeaders() {
+        if ($this->encodedSharedProtectedHeaders != null) {
+            $this->sharedProtectedHeaders = json_decode(Base64Url::decode($this->encodedSharedProtectedHeaders), true);
+        }
+    }
+    public function encrypt ($publicKey, $payload) {
+        $this->tag = null;
+        $cek = $this->createCek();
+        $this->iv = $this->createIV();
+        $aad = $this->aad === null ? null : Base64Url::encode($this->aad);
+        if ($this->encodedSharedProtectedHeaders === null) {
+            $this->setEncodedSharedProtectedHeaders();
+        }
+        $cipherText = $this->contentEncryptionAlgorithm->encryptContent($payload, $cek, $this->iv, $aad, $this->encodedSharedProtectedHeaders, $this->tag);
+        $this->ciphertext = $cipherText;
+        $this->encryptedKey = $this->keyEncryptionAlgorithm->encryptKey($publicKey, $cek);
+    }
+
+    public function toCompactJSON() {
+        return sprintf(
+            '%s.%s.%s.%s.%s',
+            $this->encodedSharedProtectedHeaders,
+            Base64Url::encode(null === $this->encryptedKey ? '' : $this->encryptedKey),
+            Base64Url::encode(null === $this->iv ? '' : $this->iv),
+            Base64Url::encode($this->ciphertext),
+            Base64Url::encode(null === $this->tag ? '' : $this->tag)
+        );
+    }
+    public function createJWEAndSerialize($publicKey, $payload, $sharedProtectedHeaders ) {
+        if (array_key_exists('alg', $this->sharedProtectedHeaders)) {
+            if ($sharedProtectedHeaders != null) {
+                $this->sharedProtectedHeaders = array_merge($this->sharedProtectedHeaders, $sharedProtectedHeaders);
+            }
+        } else {
+            $this->sharedProtectedHeaders = $sharedProtectedHeaders;
+        }
+        $this->encrypt($publicKey, $payload);
+        return $this->toCompactJSON();
+    }
+
+    public function loadJWE($jweContent) {
+        $parts = explode('.', $jweContent);
+        $this->encodedSharedProtectedHeaders = $parts[0];
+        $this->setSharedProtectedHeaders();
+        $this->encryptedKey = Base64Url::decode($parts[1]);
+        $this->iv = Base64Url::decode($parts[2]);
+        $this->ciphertext = Base64Url::decode($parts[3]);
+        $this->tag = Base64Url::decode($parts[4]);
+    }
+    public function decryptJWE($privateKey, $jweContent) {
+        $this->loadJWE($jweContent);
+        $cek = $this->keyEncryptionAlgorithm->decryptKey($privateKey, $this->encryptedKey);
+        $this->payload = $this->contentEncryptionAlgorithm->decryptContent($this->ciphertext, $cek, $this->iv, $this->aad, $this->encodedSharedProtectedHeaders, $this->tag);
+        return $this->payload;
+    }
+
+}
+?>

--- a/lib/JWT/JWE.php
+++ b/lib/JWT/JWE.php
@@ -1,5 +1,7 @@
 <?php
 namespace Juspay\JWT;
+use Exception;
+use Juspay\Exception\JuspayException;
 use Juspay\JWT\Base64Url;
 class JWE {
     /**
@@ -128,13 +130,17 @@ class JWE {
     }
 
     public function loadJWE($jweContent) {
-        $parts = explode('.', $jweContent);
-        $this->encodedSharedProtectedHeaders = $parts[0];
-        $this->setSharedProtectedHeaders();
-        $this->encryptedKey = Base64Url::decode($parts[1]);
-        $this->iv = Base64Url::decode($parts[2]);
-        $this->ciphertext = Base64Url::decode($parts[3]);
-        $this->tag = Base64Url::decode($parts[4]);
+        try {
+            $parts = explode('.', $jweContent);
+            $this->encodedSharedProtectedHeaders = $parts[0];
+            $this->setSharedProtectedHeaders();
+            $this->encryptedKey = Base64Url::decode($parts[1]);
+            $this->iv = Base64Url::decode($parts[2]);
+            $this->ciphertext = Base64Url::decode($parts[3]);
+            $this->tag = Base64Url::decode($parts[4]);
+        } catch (Exception $e) {
+            throw new JuspayException(-1, "ERROR", "jwe_error", $e->getMessage());
+        }
     }
     public function decryptJWE($privateKey, $jweContent) {
         $this->loadJWE($jweContent);

--- a/lib/JWT/JWK.php
+++ b/lib/JWT/JWK.php
@@ -1,0 +1,95 @@
+<?php
+namespace Juspay\JWT;
+use InvalidArgumentException;
+use RuntimeException;
+use const OPENSSL_KEYTYPE_RSA;
+class JWK {
+    /**
+     * @var string
+     */
+    private $values = [];
+    public function __construct($key)
+    {
+        $this->values = self::createFromKey($key);
+    }
+
+    private function createFromKey($key)
+    {
+       
+        return self::loadFromKey($key);
+    }
+
+
+
+    /**
+     * @param string $key
+     *
+     * @throws \Exception
+     *
+     * @return array
+     */
+    public function loadFromKey($key)
+    {
+        try {
+            return self::loadKeyFromDER($key);
+        } catch (\Exception $e) {
+            return self::loadKeyFromPEM($key);
+        }
+    }
+
+    private function loadKeyFromDER($key)
+    {
+        $pem = self::convertDerToPem($key);
+        return self::loadKeyFromPEM($pem);
+    }
+
+    private function loadKeyFromPEM($pem)
+    {
+
+        if (!extension_loaded('openssl')) {
+            throw new RuntimeException('Please install the OpenSSL extension');
+        }
+        self::sanitizePEM($pem);
+        $res = openssl_pkey_get_private($pem);
+        if (false === $res) {
+            $res = openssl_pkey_get_public($pem);
+        }
+        if (false === $res) {
+            throw new InvalidArgumentException('Unable to load the key.');
+        }
+
+        $details = openssl_pkey_get_details($res);
+        if (!is_array($details) || !array_key_exists('type', $details)) {
+            throw new InvalidArgumentException('Unable to get details of the key');
+        }
+        switch ($details['type']) {
+            case OPENSSL_KEYTYPE_RSA:
+                $rsa = new RSAKey($details);
+                return $rsa->values;
+            default:
+                throw new InvalidArgumentException('Unsupported key type');
+        }
+    }
+
+    private function convertDerToPem($der_data)
+    {
+        $pem = chunk_split(base64_encode($der_data), 64, PHP_EOL);
+        return '-----BEGIN CERTIFICATE-----'.PHP_EOL.$pem.'-----END CERTIFICATE-----'.PHP_EOL;
+    }
+
+    private function sanitizePEM(&$pem)
+    {
+        preg_match_all('#(-.*-)#', $pem, $matches, PREG_PATTERN_ORDER);
+        $ciphertext = preg_replace('#-.*-|\r|\n| #', '', $pem);
+
+        $pem = $matches[0][0].PHP_EOL;
+        $pem .= chunk_split($ciphertext, 64, PHP_EOL);
+        $pem .= $matches[0][1].PHP_EOL;
+    }
+    public function jsonSerialize()
+    {
+        return $this->values;
+    }
+
+}
+?>

--- a/lib/JWT/JWS.php
+++ b/lib/JWT/JWS.php
@@ -1,0 +1,112 @@
+<?php
+namespace Juspay\JWT;
+use Juspay\JWT\Base64Url;
+use Exception;
+use RuntimeException;
+class JWS {
+
+    /**
+     * @property ISigningAlgorithm $signingAlgorithm
+     */
+    private $signingAlgorithm;
+
+    /**
+     * @property string $signature
+     */
+    private $signature;
+
+    /**
+     * @property string $payload
+     */
+    public $payload;
+
+    /**
+     * @property string $encodedPayload
+     */
+    public $encodedPayload;
+
+    /**
+     * @property string $encodedProtectedHeaders
+     */
+    public $encodedProtectedHeaders;
+
+    public $protectedHeaders = [];
+
+
+    public function setEncodedPayload() {
+        if ($this->payload !== null) {
+            $this->encodedPayload = Base64Url::encode($this->payload);
+        }
+    }
+
+    public function setPayload() {
+        if ($this->encodedPayload != null) {
+            $this->payload = Base64Url::decode($this->encodedPayload);
+        }
+    }
+
+    public function setProtectedHeaders() {
+        if ($this->encodedProtectedHeaders != null) {
+            $this->protectedHeaders = json_decode(Base64Url::decode($this->encodedProtectedHeaders), true);
+        }
+    }
+    public function setEncodedProtectedHeaders() {
+        if (!empty($this->protectedHeaders) || !is_null($this->protectedHeaders)) {
+            $this->encodedProtectedHeaders = Base64Url::encode(json_encode($this->protectedHeaders));
+        }
+    }
+
+    /**
+     * @param ISigningAlgorithm $signingAlgorithm
+     */
+    public function __construct($signingAlgorithm) {
+       $this->signingAlgorithm = $signingAlgorithm;
+       $this->protectedHeaders = ["alg" => $signingAlgorithm->getAlgorithmName()];
+    }
+
+    private function getInputToSign() {
+        $this->setEncodedProtectedHeaders();
+        $this->setEncodedPayload();
+        if ($this->encodedProtectedHeaders != null && $this->encodedPayload != null) {
+            return sprintf('%s.%s', $this->encodedProtectedHeaders,  $this->encodedPayload);
+        } else {
+            throw new RuntimeException("Unable to encode payload and header");
+        }
+    }
+    /**
+     * @param JWK $key
+     * @param string $payload
+     * @param array $protectedHeaders
+     */
+    public function createJWSandSerialize($key, $payload, $protectedHeaders = null) {
+        if (array_key_exists('alg', $this->protectedHeaders)) {
+            if ($protectedHeaders != null) {
+                $this->protectedHeaders = array_merge($this->protectedHeaders, $protectedHeaders);
+            }
+        } else {
+            $this->protectedHeaders = $protectedHeaders;
+        }
+        $this->payload = $payload;
+        $encodedPayload = $this->getInputToSign();
+        $this->signature = $this->signingAlgorithm->sign($encodedPayload, $key);
+        return sprintf('%s.%s', $encodedPayload, Base64Url::encode($this->signature));
+    }
+
+    public function loadJWS($encodedSignedPayload) {
+        $parts = explode('.', $encodedSignedPayload);
+        $this->encodedPayload = $parts[1];
+        $this->encodedProtectedHeaders = $parts[0];
+        $this->signature = Base64Url::decode($parts[2]);
+        $this->setPayload();
+        $this->setProtectedHeaders();
+    }
+
+    public function verify($key, $encodedSignedPayload) {
+        $this->loadJWS($encodedSignedPayload);
+        $inputToVerify = sprintf('%s.%s', $this->encodedProtectedHeaders, $this->encodedPayload);
+        if ($this->signingAlgorithm->verifySign($inputToVerify, $this->signature, $key) != 1) {
+            throw new RuntimeException("unable to verify token");
+        };
+    }
+}
+?>

--- a/lib/JWT/RSA256.php
+++ b/lib/JWT/RSA256.php
@@ -1,6 +1,6 @@
 <?php
 namespace Juspay\JWT;
-use RuntimeException;
+use Juspay\Exception\JuspayException;
 class RSA256 extends ISigningAlgorithm {
 
     /**
@@ -11,7 +11,7 @@ class RSA256 extends ISigningAlgorithm {
         $privateKey = new RSAKey($privateKey->jsonSerialize());
         $result = openssl_sign($payload, $signature, $privateKey->toPEM(), $this->getAlgorithm());
         if ($result === false) {
-            throw new RuntimeException('An error occurred during the creation of the signature');
+            throw new JuspayException(-1, "ERROR", "jws_error", "'An error occurred during the creation of the signature");
         }
         return $signature;
         

--- a/lib/JWT/RSA256.php
+++ b/lib/JWT/RSA256.php
@@ -1,0 +1,47 @@
+<?php
+namespace Juspay\JWT;
+use RuntimeException;
+class RSA256 extends ISigningAlgorithm {
+
+    /**
+     * @param string $payload
+     * @param JWK $privateKey
+     */
+    public function sign($payload, $privateKey) {
+        $privateKey = new RSAKey($privateKey->jsonSerialize());
+        $result = openssl_sign($payload, $signature, $privateKey->toPEM(), $this->getAlgorithm());
+        if ($result === false) {
+            throw new RuntimeException('An error occurred during the creation of the signature');
+        }
+        return $signature;
+        
+    }
+
+     /**
+     * @param string $encodedPayload
+     * @param string $signature
+     * @param JWK $publicKey
+     */
+    public function verifySign($encodedPayload, $signature, $publicKey) {
+        $publicKey = new RSAKey($publicKey->jsonSerialize());
+        $res = openssl_verify($encodedPayload, $signature, $publicKey->toPEM(), $this->getAlgorithm());
+        return $res === 1;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getAlgorithm()
+    {
+        return 'sha256';
+    }
+
+    /**
+     * @return string
+     */
+    public function getAlgorithmName()
+    {
+        return 'RS256';
+    }
+}
+?>

--- a/lib/JWT/RSAKey.php
+++ b/lib/JWT/RSAKey.php
@@ -1,0 +1,75 @@
+<?php
+namespace Juspay\JWT;
+
+use Juspay\JWT\Base64Url;
+use InvalidArgumentException;
+
+class RSAKey {
+
+    public $values = [];
+    public function __construct($details) {
+        if (array_key_exists('kty', $details)) {
+            $this->values = $details;
+        
+        } else {
+            if (!array_key_exists('rsa', $details)) {
+                throw new InvalidArgumentException('Unable to get details of the rsa key');
+            }
+            $this->values['kty'] = 'RSA';
+            $keys = [
+                'n' => 'n',
+                'e' => 'e',
+                'd' => 'd',
+                'p' => 'p',
+                'q' => 'q',
+                'dp' => 'dmp1',
+                'dq' => 'dmq1',
+                'qi' => 'iqmp',
+            ];
+            foreach ($details['rsa'] as $key => $value) {
+                if (in_array($key, $keys)) {
+                    $value = Base64Url::encode($value);
+                    $this->values[array_search($key, $keys)] = $value;
+                }
+            }
+            if (!$this->isPrivate()) {
+                $this->values['key'] = $details['key'];
+            }
+        }
+    }
+
+     /**
+     * @return string
+     */
+    public function toPEM()
+    {
+        if (self::isPrivate()) {
+            $rsaParameters = [];
+            $rsaParameters['n'] = Base64Url::decode($this->values['n']);
+            $rsaParameters['e'] = Base64Url::decode($this->values['e']);
+            $rsaParameters['d'] = Base64Url::decode($this->values['d']);
+            $rsaParameters['p'] = Base64Url::decode($this->values['p']);
+            $rsaParameters['q'] = Base64Url::decode($this->values['q']);
+            $rsaParameters['dmp1'] = Base64Url::decode($this->values['dp']);
+            $rsaParameters['dmq1'] = Base64Url::decode($this->values['dq']);
+            $rsaParameters['iqmp'] = Base64Url::decode($this->values['qi']);
+            $keyResource = openssl_pkey_new([
+                'rsa' => $rsaParameters,
+            ]);
+            openssl_pkey_export($keyResource, $pemKey); 
+            return $pemKey;
+        } else {
+            return $this->values["key"];
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPrivate()
+    {
+        return array_key_exists('d', $this->values);
+    }
+  
+}
+?>

--- a/lib/JWT/RSAKey.php
+++ b/lib/JWT/RSAKey.php
@@ -1,8 +1,8 @@
 <?php
 namespace Juspay\JWT;
 
+use Juspay\Exception\JuspayException;
 use Juspay\JWT\Base64Url;
-use InvalidArgumentException;
 use phpseclib3\Crypt\PublicKeyLoader;
 
 class RSAKey {
@@ -14,7 +14,7 @@ class RSAKey {
         
         } else {
             if (!array_key_exists('rsa', $details)) {
-                throw new InvalidArgumentException('Unable to get details of the rsa key');
+                throw new JuspayException(-1, "ERROR", "jwk_error", 'Unable to get details of the rsa key');
             }
             $keys = [
                 'n' => 'n',

--- a/lib/JWT/RSAOAEP256.php
+++ b/lib/JWT/RSAOAEP256.php
@@ -1,0 +1,23 @@
+<?php
+namespace Juspay\JWT;
+use phpseclib3\Crypt\PublicKeyLoader;
+class RSAOAEP256 extends IKeyEncryption {
+    public function encryptKey(JWk $key, $cek) {
+        $rsaKey = new RSAKey($key->jsonSerialize());
+        $rsa = PublicKeyLoader::load($rsaKey->toPEM())->withHash('sha256')->withMGFHash('sha256');
+        $enc = $rsa->encrypt($cek);
+        return $enc;
+    }
+
+    public function decryptKey(JWK $key, $encryptedKey) {
+        $rsaKey = new RSAKey($key->jsonSerialize());
+        $rsa = PublicKeyLoader::load($rsaKey->toPEM())->withHash('sha256')->withMGFHash('sha256');
+        $decrypted = $rsa->decrypt($encryptedKey);
+        return $decrypted;
+    }
+
+    public function getAlgorithmName() {
+        return 'RSA-OAEP-256';
+    }
+}
+?>

--- a/lib/Model/EncRSAOEAP.php
+++ b/lib/Model/EncRSAOEAP.php
@@ -1,20 +1,13 @@
 <?php
 namespace Juspay\Model;
 
-use Exception;
-use Jose\Component\Encryption\Algorithm\ContentEncryption\A256GCM;
-use Jose\Component\Encryption\Algorithm\KeyEncryption\RSAOAEP256;
-use Jose\Component\Encryption\Compression\CompressionMethodManager;
-use Jose\Component\Encryption\JWEBuilder;
-use Jose\Component\Core\AlgorithmManager;
-use Jose\Component\Encryption\JWEDecrypter;
-use Jose\Component\Encryption\JWELoader;
-use Jose\Component\Encryption\Serializer\CompactSerializer;
-
-
-use Jose\Component\Encryption\Serializer\JWESerializerManager;
-use Jose\Component\KeyManagement\JWKFactory;
-
+use Jose\Factory\JWEFactory;
+use Jose\Factory\JWKFactory;
+use Jose\Loader;
+use Juspay\JWT\AES256GCM;
+use Juspay\JWT\JWE;
+use Juspay\JWT\JWK;
+use Juspay\JWT\RSAOAEP256;
 
 class EncRSAOEAP extends IEnc {
 
@@ -26,7 +19,6 @@ class EncRSAOEAP extends IEnc {
     public function __construct($kid) {
         $this->kid = $kid;
     }
-
      /**
      * Encrypt the payload
      * @param string $publicKey Key used to encrypt the payload/encrypt the encryption key
@@ -34,62 +26,20 @@ class EncRSAOEAP extends IEnc {
      * @return string Encrypted payload
      */
     public function encrypt($publicKey, $payload) {
-        $publicJWKKey = JWKFactory::createFromKey($publicKey);
-        if (version_compare(phpversion(), '7.2.0', '>=')) {
-            $jweBuilder = new JWEBuilder(
-                new AlgorithmManager([new RSAOAEP256()]),   
-                new AlgorithmManager([new A256GCM()]),
-                new CompressionMethodManager([
-                ])
-            );
-        } else {
-            $jweBuilder = new JWEBuilder(
-                null,
-                new AlgorithmManager([new RSAOAEP256()]),   
-                new AlgorithmManager([new A256GCM()]),
-                new CompressionMethodManager([
-                ])
-            );
-        }
-        $jweVar = $jweBuilder->create()->withPayload($payload)->withSharedProtectedHeader([
-            'alg' => 'RSA-OAEP-256',    
-            'enc' => 'A256GCM',
-            'kid' => $this->kid,
-        ])->addRecipient($publicJWKKey)->build();
-        
-        $serializer = new CompactSerializer(); 
-        
-        return $serializer->serialize($jweVar, 0);
-        
+        $publicJWKKey = new JWK($publicKey);
+        $jwe = new JWE(new RSAOAEP256(), new AES256GCM());
+        return $jwe->createJWEAndSerialize($publicJWKKey, $payload, ['kid' => $this->kid]);    
     }
-
-    /**
+     /**
      * Decrypt the encrypted payload
      * @param string $privateKey Key used to decrypt the payload/decrypt the encryption key
      * @param string $encryptedPayload Payload to be decrypted
      * @return string Encrypted payload
      */
     public function decrypt($privateKey, $encryptedPayload) {
-        $privateJWKKey = JWKFactory::createFromKey($privateKey);
-        $serializerManager = new JWESerializerManager([
-            new CompactSerializer(),
-        ]);
-        $jweDecrypter = new JWEDecrypter(
-            new AlgorithmManager([new RSAOAEP256()]),
-            new AlgorithmManager([new A256GCM()]),
-            new CompressionMethodManager([
-            ])
-        );
-        $jweLoader = new JWELoader(
-            $serializerManager,
-            $jweDecrypter,
-            null
-        );
-        $jwe = $jweLoader->loadAndDecryptWithKey($encryptedPayload, $privateJWKKey, $recipient);
-        if ($jwe->getSharedProtectedHeader()["alg"] == "RSA-OAEP-256") {
-            return $jwe->getPayload();
-        }
-        throw new Exception('Unable to load and verify the token.');
+        $privateJWKKey = new JWK($privateKey);
+        $jwe = new JWE(new RSAOAEP256(), new AES256GCM());
+        return $jwe->decryptJWE($privateJWKKey, $encryptedPayload);
     }
 }
 ?>

--- a/lib/Model/SignRSA.php
+++ b/lib/Model/SignRSA.php
@@ -1,53 +1,32 @@
 <?php
 namespace Juspay\Model;
+use Juspay\JWT\JWK;
+use Juspay\JWT\JWS;
+use Juspay\JWT\RSA256;
 
-use Jose\Component\Signature\JWSLoader;
-use Jose\Component\Signature\JWSVerifier;
-use Jose\Component\Core\AlgorithmManager;
-
-use Jose\Component\KeyManagement\JWKFactory;
-use Jose\Component\Signature\Algorithm\RS256;
-use Jose\Component\Signature\JWSBuilder;
-use Jose\Component\Signature\Serializer\CompactSerializer;
-use Jose\Component\Signature\Serializer\JWSSerializerManager;
 
 class SignRSA extends ISign {
 
     public $kid;
+    
     /**
     * 
     * @param string $kid private key key id
     */
-    public function __construct(string $kid) {
+    public function __construct($kid) {
         $this->kid = $kid;
     }
 
-     /**
-     * Signer
-     * @param string $privateKey Key used to sing
-     * @param string $payload Payload to be signed
-     * @return string Returns signed string
-     */
+    /**
+    * 
+    * @param string $privateKey Key used to sing
+    * @param string $payload Payload to be signed
+    * @return string Returns signed string
+    */
     public function sign($privateKey, $payload) {
-        $privateJWKKey = JWKFactory::createFromKey($privateKey);
-        if (version_compare(phpversion(), '7.2.0', '>=')) {
-            $jwsBuilder = new JWSBuilder(
-                new AlgorithmManager([new RS256()])
-            );
-        } else {
-            $jwsBuilder = new JWSBuilder(
-                null,
-                new AlgorithmManager([new RS256()])
-            );
-        }
-        $jws = $jwsBuilder
-                ->create()
-                ->withPayload($payload)
-                ->addSignature($privateJWKKey, ['alg' => 'RS256', 'kid' => $this->kid])
-                ->build();
-        $serializer = new CompactSerializer();
-
-        return $serializer->serialize($jws, 0); 
+        $privateJWKKey = new JWK($privateKey);
+        $jws = new JWS(new RSA256());
+        return $jws->createJWSandSerialize($privateJWKKey, $payload, ['kid' => $this->kid]);
     }
 
     /**
@@ -57,20 +36,10 @@ class SignRSA extends ISign {
      * @return string Decoded payload
      */
     public function verifySign($publicKey, $signedPayload) {
-        $publicJWKKey = JWKFactory::createFromKey($publicKey);
-        $jwsVerifier = new JWSVerifier(
-            new AlgorithmManager([new RS256()])
-        );
-        $serializerManager = new JWSSerializerManager([
-            new CompactSerializer(),
-        ]);
-        $jwsLoader = new JWSLoader(
-            $serializerManager,
-            $jwsVerifier,
-            null
-        );
-        $jws = $jwsLoader->loadAndVerifyWithKey($signedPayload, $publicJWKKey, $signature);
-        return $jws->getPayload();
+        $publicJWKKey = new JWK($publicKey);
+        $jws = new JWS(new RSA256());
+        $jws->verify($publicJWKKey, $signedPayload);
+        return $jws->payload;
     }
 }
 ?>

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -1,0 +1,112 @@
+<?php
+namespace Juspay\Test;
+
+use Exception;
+use Juspay\JWT\Base64Url;
+use Juspay\JWT\AES256GCM;
+use Juspay\JWT\JWE;
+use Juspay\JWT\JWK;
+use Juspay\JWT\JWS;
+use Juspay\JWT\RSA256;
+use Juspay\JWT\RSAKey;
+use Juspay\JWT\RSAOAEP256;
+
+class JWTTest extends TestCase {
+    public function testReadPrivateKeyInPkcs1(){
+        $keyString = file_get_contents("./tests/testPrivateKeyPkcs1.pem");
+        $keyStringPkcs8 = file_get_contents("./tests/testPrivateKeyPkcs8.pem");
+        $key = new JWK($keyString);
+        $RsaKey = new RSAKey($key->jsonSerialize());
+        $this->assertTrue(preg_replace('#|\r|\n| #', '',$keyStringPkcs8) == preg_replace('#|\r|\n| #', '',$RsaKey->toPEM()));
+    }
+
+    public function testReadPrivateKeyInPkcs8() {
+        $keyString = file_get_contents("./tests/testPrivateKeyPkcs8.pem");
+        $key = new JWK($keyString);
+        $RsaKey = new RSAKey($key->jsonSerialize());
+        $this->assertTrue(preg_replace('#|\r|\n| #', '',$keyString) == preg_replace('#|\r|\n| #', '',$RsaKey->toPEM()));
+    }
+
+    public function testSigning() {
+        $keyString = file_get_contents("./tests/privateKey.pem");
+        $key = new JWK($keyString);
+        $jws = new JWS(new RSA256());
+        $payload = "hello world";
+        $jwsJuspay = $jws->createJWSandSerialize($key, $payload, ['kid' => "key_xxxxx"]);
+        $this->assertTrue("eyJhbGciOiJSUzI1NiIsImtpZCI6ImtleV94eHh4eCJ9.aGVsbG8gd29ybGQ.NYXOlfiLgR9JzKi9t23CkaHVfrYRQRM2MV1v2piMFHldpKG5MI9CcE444P-9C17YanGFpC4ll_aDz9sWOUEGZHg6l_hp2WtrZqZ4YlC9NaXdq2e7Qen6ABE1R-W6XZGYDHkTgtkcGaNDr-jA4U9JEaTfB0dd5-217hVA5yHnhICW3J3llDgRNibU9TyRtq8ijO0ye0cJNjr47ugm_Dx6slSVB6QayT8sfBTHULsIVL3LX9DQNnWOGWG_ck6usjKzPYMMurcedOgUTkLOJcPIdeeAHrm27OD17L3I8viTCqrqxpoiYTjJvYaa7cGe7rH0-T2QH8NOqWwd2BZSCo93oA" == $jwsJuspay);
+        return $jwsJuspay;
+    }
+
+    public function testVerifySignature($signedPayload = null) {
+        $keyString = file_get_contents("./tests/publicPairPrivate.pem");
+        $signedPayload = null === $signedPayload ? "eyJhbGciOiJSUzI1NiIsImtpZCI6ImtleV94eHh4eCJ9.aGVsbG8gd29ybGQ.NYXOlfiLgR9JzKi9t23CkaHVfrYRQRM2MV1v2piMFHldpKG5MI9CcE444P-9C17YanGFpC4ll_aDz9sWOUEGZHg6l_hp2WtrZqZ4YlC9NaXdq2e7Qen6ABE1R-W6XZGYDHkTgtkcGaNDr-jA4U9JEaTfB0dd5-217hVA5yHnhICW3J3llDgRNibU9TyRtq8ijO0ye0cJNjr47ugm_Dx6slSVB6QayT8sfBTHULsIVL3LX9DQNnWOGWG_ck6usjKzPYMMurcedOgUTkLOJcPIdeeAHrm27OD17L3I8viTCqrqxpoiYTjJvYaa7cGe7rH0-T2QH8NOqWwd2BZSCo93oA" : $signedPayload;
+        $key = new JWK($keyString);
+        $jwsJuspay = new JWS(new RSA256());
+        $jwsJuspay->verify($key, $signedPayload);
+        $this->assertTrue(null !== $jwsJuspay->payload);
+    }
+
+    public function testVerifySignatureFailureCase() {
+        $keyString = file_get_contents("./tests/publicPairPrivate.pem");
+        $signedPayload = "eyJhbGciOiJSUzI1NiJ9.aGVsbG8gd29ybGQ.NYXOlfiLgR9JzKi9t23CkaHVfrYRQRM2MV1v2piMFHldpKG5MI9CcE444P-9C17YanGFpC4ll_aDz9sWOUEGZHg6l_hp2WtrZqZ4YlC9NaXdq2e7Qen6ABE1R-W6XZGYDHkTgtkcGaNDr-jA4U9JEaTfB0dd5-217hVA5yHnhICW3J3llDgRNibU9TyRtq8ijO0ye0cJNjr47ugm_Dx6slSVB6QayT8sfBTHULsIVL3LX9DQNnWOGWG_ck6usjKzPYMMurcedOgUTkLOJcPIdeeAHrm27OD17L3I8viTCqrqxpoiYTjJvYaa7cGe7rH0-T2QH8NOqWwd2BZSCo93oA";
+        $key = new JWK($keyString);
+        $jwsJuspay = new JWS(new RSA256());
+        try {
+            $jwsJuspay->verify($key, $signedPayload);
+        } catch (Exception $e) {
+           $this->assertTrue($e->getMessage() == "unable to verify token");
+        }   
+    }
+    public function keyEncryption() {
+        $cek = base64_decode("6H6blPsPec6BmobOn/92haednPljSamTWFLCMwhvpzo=");
+        $keyString = file_get_contents("./tests/publicPairPrivate.pem");
+        $key = new JWK($keyString);
+        $rsaOeap = new RSAOAEP256();
+        $encryptedContent = $rsaOeap->encryptKey($key, $cek);
+        $this->assertTrue($encryptedContent != null);
+        return $encryptedContent;
+    }
+    public function testKeyDecryption() {
+        $encryptedKey = $this->keyEncryption();
+        $keyString = file_get_contents("./tests/privateKey.pem");
+        $key = new JWK($keyString);
+        $rsaOeap = new RSAOAEP256();
+        $decryptedKey = $rsaOeap->decryptKey($key, $encryptedKey);
+        $this->assertTrue("6H6blPsPec6BmobOn/92haednPljSamTWFLCMwhvpzo=" === base64_encode($decryptedKey));
+    }
+
+    public function contentEncryption() {
+        $payload = 'hello world';
+        $privateKey = file_get_contents("./tests/privateKey.pem");
+        $privateKeyJuspay = new JWK($privateKey);
+        $jws = new JWS(new RSA256());
+        $signedPayload = $jws->createJWSandSerialize($privateKeyJuspay, $payload,  ['kid' => "key_xxxxx"]);
+        $signedPayload = explode(".", $signedPayload);
+        $signedPayload = "{\"header\":\"{$signedPayload[0]}\",\"payload\":\"{$signedPayload[1]}\",\"signature\":\"{$signedPayload[2]}\"}";
+        $publicKey = file_get_contents("./tests/publicPairPrivate.pem");
+        $publicKeyJuspay = new JWK($publicKey);
+        $JWE = new JWE(new RSAOAEP256(), new AES256GCM());
+        $jweJuspay = $JWE->createJWEAndSerialize($publicKeyJuspay, $signedPayload, ['kid' => "key_xxxxx"]);
+        $encryptedPayload = explode('.', $jweJuspay);
+        $this->assertTrue($encryptedPayload !== null);
+        $headers = json_decode(base64_decode($encryptedPayload[0]), true);
+        $this->assertTrue($headers["kid"] === "key_xxxxx");
+        $this->assertTrue($headers["alg"] === "RSA-OAEP-256");
+        $this->assertTrue($headers["enc"] === "A256GCM");
+        return $encryptedPayload;
+    }
+
+    public function testContentDecryption() {
+        $encryptedPayload = $this->contentEncryption();
+        $payload = "{$encryptedPayload[0]}.{$encryptedPayload[1]}.{$encryptedPayload[2]}.{$encryptedPayload[3]}.{$encryptedPayload[4]}";
+        $privateKey = file_get_contents("./tests/privateKey.pem");
+        $privateKeyJuspay = new JWK($privateKey);
+        $JWE = new JWE(new RSAOAEP256(), new AES256GCM());
+        $signedPayload = json_decode($JWE->decryptJWE($privateKeyJuspay, $payload), true);
+        $this->assertTrue(Base64Url::decode($signedPayload["payload"]) === 'hello world');
+        $signedPayload = "{$signedPayload["header"]}.{$signedPayload["payload"]}.{$signedPayload["signature"]}";
+        $this->testVerifySignature($signedPayload);
+    }
+}
+require_once __DIR__ . '/TestEnvironment.php';
+?>

--- a/tests/OrderTest.php
+++ b/tests/OrderTest.php
@@ -15,7 +15,7 @@ class OrderTest extends TestCase {
         $orderId = uniqid ();
         $params = array ();
         $params ['order_id'] = $orderId;
-        $params ['amount'] = 500.0;
+        $params ['amount'] = "100.0";
         $params ['currency'] = "INR";
         $params ['customer_id'] = "juspay_test_1";
         $params ['customer_email'] = "test@juspay.in";
@@ -99,7 +99,7 @@ class OrderTest extends TestCase {
         $params = array ();
         $params ['order_id'] = $this->order->orderId;
         $params['unique_request_id'] = uniqid('php_sdk_test_');
-        $params['amount']= $this->order->amount;
+        $params['amount']= (float)$this->order->amount;
         $privateKey = file_get_contents("./tests/privateKey.pem");
         $publicKey = file_get_contents("./tests/publicKey.pem");
         try {
@@ -115,7 +115,7 @@ class OrderTest extends TestCase {
         $params = array ();
         $params ['order_id'] = $this->order->orderId;
         $params['unique_request_id'] = uniqid('php_sdk_test_');
-        $params['amount']= $this->order->amount;
+        $params['amount']= (float)$this->order->amount;
         $privateKey = file_get_contents("./tests/privateKey.pem");
         $publicKey = file_get_contents("./tests/publicKey.pem");
         JuspayEnvironment::init()->withJuspayJWT(new JuspayJWT("key_26b1a82e16cf4c6e850325c3d98368cb", $publicKey, $privateKey));
@@ -140,7 +140,7 @@ class OrderTest extends TestCase {
         $this->testCreate ();
         $params = array ();
         $orderId = $this->order->orderId;
-        $params ['amount'] = $this->order->amount + 100;
+        $params ['amount'] = ((float)$this->order->amount) + 100;
         $order = Order::update ( $params, $orderId );
         $this->assertTrue ( $order != null );
         $this->assertTrue ( $order->amount == $params ['amount'] );

--- a/tests/TestEnvironment.php
+++ b/tests/TestEnvironment.php
@@ -18,6 +18,4 @@ class TestEnvironment {
 new TestEnvironment();
 JuspayEnvironment::init ()
 ->withApiKey ( TestEnvironment::$apiKey )
-->withBaseUrl ( TestEnvironment::$baseUrl )
-->withLogLevel(JuspayLogLevel::Debug)
-->withLogFilePath("log/juspay_test.log");
+->withBaseUrl ( TestEnvironment::$baseUrl );


### PR DESCRIPTION
- Removed JWT external Library
- Added support for RSA256 for JWS
- Added support for RSAOAEP and AES256GCM
- Integrated custom JWT into sdk
- Removed dependency of gmp and bcmath

Extension required for current version
1. openssl or gmp or bcmath
2. curl
3. json
4. sodium

- [x] Docker Linux testing (php 7.1 & 8.3)
- [x] Mac testing (php 5.6, 7.1, 7.2, 8.0, 8.1, 8.2)
- [x] Windows testing
- [ ]  ~~Remove logger~~